### PR TITLE
Fix CFQ check

### DIFF
--- a/riak-check-debug.py
+++ b/riak-check-debug.py
@@ -97,7 +97,7 @@ mainconfig = {
     'System Report': {
         'commands/schedulers': {
             'match': {
-                'cfq': 'CFQ (Completely Fair Queueing)'
+                '\[cfq\]': 'CFQ (Completely Fair Queueing)'
             }
         }
     },


### PR DESCRIPTION
The match of “cfq” finds schedulers that aren’t using CFQ but have CFQ available as an option. When CFQ is used the value is “[cfq]”.