### PR TITLE
Clarify the logdir's datetime string

### DIFF
--- a/riak-check-debug.py
+++ b/riak-check-debug.py
@@ -163,7 +163,7 @@ baseDirs = []
 files = []
 
 ## directory to log all files to
-logdir = 'riak-check-debug-logs-' + str(datetime.datetime.now()).replace(' ', '').replace(':', '.')
+logdir = 'riak-check-debug-logs-' + str(datetime.datetime.now()).replace(' ', '_').replace(':', '.')
 
 ## all the report data built for logging and display
 report = defaultdict()


### PR DESCRIPTION
without this change, the logdir generates in the form `logs-YYYY-MM-DDHH.MM.SS`. With the change it's `MM-DD_HH.MM`.
