### PR TITLE
Make "s around sibling object names optional

### DIFF
--- a/riak-check-debug.py
+++ b/riak-check-debug.py
@@ -138,7 +138,7 @@ mainconfig = {
                     'format': '(%s) bytes %s',
                     'replace': [('<', ''), ('>', ''), ('"', '')]
                 },
-                'Too many siblings for object (<<\".*\">>/<<\".*\">>) (\([0-9]+\))': {
+                'Too many siblings for object (<<\"?.*\"?>>/<<\"?.*\"?>>) (\([0-9]+\))': {
                     'description': 'Object with too many siblings',
                     'format': '%s has %s siblings',
                     'replace': [('<', ''), ('>', ''), ('"', '')]


### PR DESCRIPTION
Like it says on the tin.

Modified to catch logs similar to,

```
2016-11-29 22:52:21.132 [warning] <0.1323.0>@riak_kv_vnode:encode_and_put:2162 Too many siblings for object <<48,98,58,233,17,58,105,142,171,140,218,8,161,19,158,180,210,161,173>>/<<174,111,37,160,69,183,71,170,171,14,213,63,238,159,101,193,0,0,0,0>> (11)
```