### PR TITLE
Catching Certificate Error and CRL Messages

### DIFF
--- a/riak-check-debug.py
+++ b/riak-check-debug.py
@@ -118,6 +118,10 @@ mainconfig = {
                 'emfiles': 'Found file handle exhaustion (emfiles)',
                 'system_limit': 'Found Erlang resource exhaustion (system_limit)',
                 'Corruption': 'Found AAE Hashtree Corruption'
+            },
+            'match': {
+                    'no CRL': 'CRL Checking Enabled or is Invalid',
+                    'certificate unknown': 'Verify Correctness of Configured Certificates (Generation, Configuration, Client Usage)'
             }
         }
     },


### PR DESCRIPTION
In line with the security ticket I have worked on, Joe has written an improvement to the Riak Security handling to pipe out the problems when CRL is enabled (by default) and no CRLs are provided with the clients being used to connect to the Riak Security enabled nodes. 

The `certificate unknown` message is a bit generic but can span problems as invalid certificates used, misconfiguration or improper certificate in client use.