### PR TITLE
Update riak-check-debug.py

### DIFF
--- a/riak-check-debug.py
+++ b/riak-check-debug.py
@@ -122,7 +122,10 @@ mainconfig = {
             'match': {
                     'no CRL': 'CRL Checking Enabled or is Invalid',
                     'certificate unknown': 'Verify Correctness of Configured Certificates (Generation, Configuration, Client Usage)'
-            }
+            },
+            'submatch': {
+                "proxy_riak_kv_vnode_([0-9]+) .*Corruption": "Corrupted partition in %s:\n\tpartition: %s"
+                }
         }
     },
     'Riak Console Log Report': {


### PR DESCRIPTION
Added `error.log` submatch section to catch corrupted partitions. 

Using failed to start [1] as a basis of catching the error might be incomplete. This will only trigger when starting and could possibly report ONLY the first occurance of the corrupted partition. 

[1] `"Failed to start .*? for index ([0-9]+) .*Corruption": "Corrupted partition in %s:\n\tpartition: %s`